### PR TITLE
Add BCubium from Bgeometrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@
 - HTC Exodus 1s
   [@htcexodus](https://twitter.com/htcexodus)
   https://www.htcexodus.com/us/cryptophone/exodus1s/
+- BCubium
+  [@BGeometrics](https://twitter.com/BGeometrics)
+  https://bgeometrics.com/
     
 ## Software - without dedicated Hardware
 - cyphernode


### PR DESCRIPTION
I request to include the full node Bitcoin [BCubium](https://bcubium.com) from [BGeometrics](https://bgeometrics.com) that on 5/15/2020 will kickstarter crowdfunding campaign.